### PR TITLE
Update Animate.js

### DIFF
--- a/modules/Animate.js
+++ b/modules/Animate.js
@@ -4,7 +4,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 export default class extends Component {
 
   static propTypes = {
-    children: PropTypes.any.isRequired,
+    //children: PropTypes.any.isRequired,
     animationEnter: PropTypes.string.isRequired,
     animationLeave: PropTypes.string.isRequired,
     durationEnter: PropTypes.number.isRequired,


### PR DESCRIPTION
**When the props.chilren was null, the console throws a warning.**

The part of my code like below:

```
render() {
    let comp = this.state.loading ? <loading /> : null
    return (
       <Animate
          animationEnter='fadeIn'
          animationLeave='fadeOut'
          durationEnter={300}
          durationLeave={300}
          component='div'
        >
          {comp}
        </Animate>
    )
}
```

**I fixed this**
